### PR TITLE
Add regression testing of unit operations

### DIFF
--- a/.github/workflows/test_vebio.yml
+++ b/.github/workflows/test_vebio.yml
@@ -11,13 +11,21 @@ on:
 
 jobs:
   build:
-    name: test_vebio
-    runs-on: ubuntu-latest
+    name: test_vebio - ${{ matrix.os }}
+    runs-on: ${{ matrix.os-version }}
     strategy:
       fail-fast: false
       matrix:
         python-version:
           - '3.7'
+        os:
+          - linux
+          - macos
+        include:
+          - os: linux
+            os-version: ubuntu-20.04
+          - os: macos
+            os-version: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2

--- a/vebio/tests/pytest.ini
+++ b/vebio/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    unit: A short test that relies mostly on quick pass/fail outcomes.
+    regression: A longer test that requires solving a unit model and comparing floating point results.
+    

--- a/vebio/tests/test_FileModifiers.py
+++ b/vebio/tests/test_FileModifiers.py
@@ -43,6 +43,7 @@ def buid_test_dict():
 
     return replacement_dict
 
+@pytest.mark.unit
 def test_replacement(build_test_file, buid_test_dict, build_truth_file):
 
     test_file = build_test_file

--- a/vebio/tests/test_RunFunctions.py
+++ b/vebio/tests/test_RunFunctions.py
@@ -1,0 +1,114 @@
+import pytest
+import os
+from ipywidgets import *
+import shutil
+
+from vebio.RunFunctions import run_pretreatment, run_enzymatic_hydrolysis, run_bioreactor
+from vebio.WidgetFunctions import WidgetCollection
+from vebio.Utilities import yaml_to_dict
+
+
+notebook_dir = os.getcwd()
+params_filename = 'test_params.yaml'
+
+
+@pytest.fixture()
+def build_fs_options():
+    fs_options = WidgetCollection()
+
+    fs_options.xylan_solid_fraction = widgets.BoundedFloatText(value = 0.263)
+    fs_options.glucan_solid_fraction = widgets.BoundedFloatText(value = 0.40)
+    fs_options.initial_porosity = widgets.BoundedFloatText(value = 0.8)
+
+    return fs_options
+
+@pytest.fixture()
+def build_pt_options():
+    pt_options = WidgetCollection()
+
+    pt_options.initial_acid_conc = widgets.BoundedFloatText(value = 0.0001)
+    pt_options.steam_temperature = widgets.BoundedFloatText(value = 150.0)
+    pt_options.steam_temperature.scaling_fn = lambda C : C + 273.15
+    pt_options.initial_solid_fraction = widgets.BoundedFloatText(value = 0.745)
+    pt_options.final_time = widgets.BoundedFloatText(value = 8.3)
+    pt_options.final_time.scaling_fn = lambda s : 60.0 * s
+    pt_options.show_plots = widgets.Checkbox(value = False)
+
+    return pt_options
+
+@pytest.fixture()
+def build_eh_options():
+    eh_options = WidgetCollection()
+
+    eh_options.model_type = widgets.RadioButtons(
+        options = ['Lignocellulose Model', 'CFD Surrogate', 'CFD Simulation'],value = 'CFD Surrogate')
+    eh_options.lambda_e = widgets.BoundedFloatText(value = 30.0,)
+    eh_options.lambda_e.scaling_fn = lambda e : 0.001 * e
+    eh_options.fis_0 = widgets.BoundedFloatText(value = 0.05)
+    eh_options.t_final = widgets.BoundedFloatText(value = 24.0)
+    eh_options.show_plots = widgets.Checkbox(value = False)
+
+    return eh_options
+
+@pytest.fixture()
+def build_br_options():
+    br_options = WidgetCollection()
+
+    br_options.model_type = widgets.RadioButtons(
+        options = ['CFD Surrogate', 'CFD Simulation'],value = 'CFD Surrogate')
+    br_options.t_final = widgets.BoundedFloatText(value = 100.0)
+
+    return br_options
+
+
+@pytest.mark.regression
+def test_run_pt(build_fs_options, build_pt_options):
+    fs_options = build_fs_options
+    pt_options = build_pt_options
+
+    run_pretreatment(notebook_dir, params_filename, fs_options, pt_options)
+
+    test_values = yaml_to_dict(params_filename)
+
+    truth_values = {'fis_0': 0.31765314961287994,
+                    'conv': 0.028073229915110083,
+                    'X_X': 0.2575180632106229,
+                    'X_G': 0.40297527098473657,
+                    'rho_x': 3.4623134078020046,
+                    'rho_f': 0.0004599638814971187}
+
+    _assert_dictionary_agreement(test_values['pretreatment_output'], truth_values)
+
+@pytest.mark.regression
+def test_run_eh_surrogate(build_eh_options):
+    eh_options = build_eh_options
+
+    run_enzymatic_hydrolysis(notebook_dir, params_filename, eh_options, False)
+
+    test_values = yaml_to_dict(params_filename)
+
+    truth_values = {'rho_g': 11.419105159857235,
+                    'rho_x': 10.406950179753244,
+                    'rho_sL': 7.7044046618903765,
+                    'rho_f': 7.240033383230595e-05}
+
+    _assert_dictionary_agreement(test_values['enzymatic_output'], truth_values)
+
+@pytest.mark.regression
+def test_run_br_surrogate(build_br_options):
+    br_options = build_br_options
+    
+    run_bioreactor(notebook_dir, params_filename, br_options, False)
+
+    test_values = yaml_to_dict(params_filename)
+
+    truth_values = {'our': 0.05755705710733422}
+
+    _assert_dictionary_agreement(test_values['bioreactor_output'], truth_values)
+
+@pytest.mark.regression
+def _assert_dictionary_agreement(test, truth):
+
+    for key, val in truth.items():
+        assert key in test
+        assert val == pytest.approx(test[key])

--- a/vebio/tests/test_Utilities.py
+++ b/vebio/tests/test_Utilities.py
@@ -8,6 +8,7 @@ from vebio.Utilities import get_host_computer, print_dict, dict_to_yaml, yaml_to
 
 test_yaml_filename = 'temp.yaml'
 
+@pytest.mark.unit
 def test_get_host_computer():
     # Test with the current environment variable
     hpc_run = get_host_computer()
@@ -21,6 +22,7 @@ def test_get_host_computer():
     # Clean up the manually-set variable
     del os.environ['NREL_CLUSTER']
 
+@pytest.mark.unit
 def test_print_dict():
 
     input_dict = {'A': 100, 'B': {'x': 10, 'y': 20, 'z': {'m': 1, 'n': 2}}, 'C': 200}
@@ -44,6 +46,7 @@ def test_print_dict():
     for k, j in zip(output, truth_value):
         assert k == j
 
+@pytest.mark.unit
 def test_dict_to_yaml():
     
     input_dict = {'model_type_1': 'CFD Surrogate', 'initial_porosity_1': 0.234, 'show_plots_1': False}
@@ -57,6 +60,7 @@ def test_dict_to_yaml():
         assert key in output_dict
         assert input_dict[key] == output_dict[key]
 
+@pytest.mark.unit
 def test_dict_to_yaml_multi_merge():
     
     input_dict_a = {'model_type_2': 'Batch Model', 'initial_porosity_2': 0.345, 'show_plots_2': True}
@@ -77,6 +81,7 @@ def test_dict_to_yaml_multi_merge():
         assert key in output_dict
         assert val == output_dict[key]
 
+@pytest.mark.unit
 def test_yaml_to_dict():
     
     output_dict = yaml_to_dict(test_yaml_filename)

--- a/vebio/tests/test_WidgetFunctions.py
+++ b/vebio/tests/test_WidgetFunctions.py
@@ -4,6 +4,7 @@ from ipywidgets import *
 
 from vebio.WidgetFunctions import WidgetCollection, ValueRangeWidget
 
+@pytest.mark.unit
 def test_widget_collection():
     test_options = WidgetCollection()
 
@@ -30,6 +31,7 @@ def test_widget_collection():
         assert test_dict[key] == pytest.approx(val)
 
 
+@pytest.mark.unit
 def test_value_range_widget():
     vrw = ValueRangeWidget('Porosity', 'The value of porosity.', [0.0, 1.0], [0.1, 0.9], 0.01)
 


### PR DESCRIPTION
The PR is intended to supersede #2 because here we modify only the testing files and the github workflow. We ignore any of the changes that were made to support the inclusion of the Fortran pretreatment module (there was a long commit history of trial and error to build the Fortran code on the github actions instance) since it will shortly be replaced with a Python alternative. 

Changes:
- Add a matrix of tests to include both linux and mac os systems
- Mark all tests as either `unit` or `regression`
- Establish the definitions of the `unit` and `regression` tags
- Introduce a new file, `test_RunFunctions.py` which can be used as a template for building the unit/module regression tests

Note: The `test_RunFunctions.py` code is currently out of date and will not work as written with the latest VE changes including the removal of the `ve_params.yaml` file. It is included here only as a jumping off point for pytest templating.